### PR TITLE
Fix warnings makefile

### DIFF
--- a/events.c
+++ b/events.c
@@ -73,13 +73,17 @@ void events_init(GtkSourceBuffer* sourcebuffer) {
 void events_openFile(char* filename, GtkSourceBuffer *sourcebuffer) {
   FILE* f_input = NULL;
   char *contents;
-  int length = 0;
+  int length = 0, read;
 
   if((f_input = fopen(filename, "r"))) {
     length = fileLength(f_input);
     contents = (char*)calloc(length, sizeof(char));
     rewind(f_input);
-    fread(contents, sizeof(char), length, f_input);
+    read = fread(contents, sizeof(char), length, f_input);
+    //Check length read in is equal to file length minus EOF char
+    if(read != (length - 1)){
+      printf("Warning: Length of file %d characters, length read %d characters\n", (length -1), read);
+    }
     gtk_text_buffer_set_text(GTK_TEXT_BUFFER(sourcebuffer), contents, -1);
     fclose(f_input);
     free(contents);  

--- a/makefile
+++ b/makefile
@@ -24,10 +24,10 @@ linux : $(CFILES)
 	gcc $(CFILES) -o $(NAME) $(OFLAGS) $(CFLAGS) $(linuxGTK) $(linuxLIBS)
 
 mac : $(CFILES)
-	gcc $(CFILES) -o $(NAME) $(CFLAGS) $(macGTK) $(macFRAMEWORKS) $(macINCLUDES)
+	gcc $(CFILES) -o $(NAME) $(OFLAGS) $(CFLAGS) $(macGTK) $(macFRAMEWORKS) $(macINCLUDES)
 
 win : $(CFILES)
-	gcc $(CFILES) -o $(NAME).exe $(CFLAGS) $(winINCLUDES) $(winGTK)
+	gcc $(CFILES) -o $(NAME).exe  $(OFLAGS) $(CFLAGS) $(winINCLUDES) $(winGTK)
 
 
 

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ winGTK = `pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0 gtksourcevie
 $(NAME) :
 
 linux : $(CFILES)
-	gcc $(CFILES) -o $(NAME) $(CFLAGS) $(linuxGTK) $(linuxLIBS)
+	gcc $(CFILES) -o $(NAME) $(OFLAGS) $(CFLAGS) $(linuxGTK) $(linuxLIBS)
 
 mac : $(CFILES)
 	gcc $(CFILES) -o $(NAME) $(CFLAGS) $(macGTK) $(macFRAMEWORKS) $(macINCLUDES)

--- a/text.c
+++ b/text.c
@@ -55,7 +55,7 @@ void text_receiveUpdate(char *input_string) {
 }
 
 void instructionControl(char *string_pointer) {
-  char* buttonID;
+  char* buttonID = NULL;
   int instruction_to_execute;
 
   if (!string_pointer) {


### PR DESCRIPTION
Added -o3 flag for linux, mac, and windows in makefile
Fixed compiler warnings when compiling with -o3
